### PR TITLE
Add stan structure models

### DIFF
--- a/stan/Gumble_Copula_Model.stan
+++ b/stan/Gumble_Copula_Model.stan
@@ -1,0 +1,83 @@
+// Gumble Copula model 
+// For a best case "edge weights" P, one may need to initalize the structure. 
+
+// Proposes graph structures (edge probabilities) and reports a tail dependence
+// Intended to be used with extreme value distributions (e.g. flow data) where rare, extreme, populations are of primary interest
+
+data {
+  int<lower=0> N;           // Number of samples
+  int<lower=0> P;           // Number of variables
+  matrix[N, P] U;           // Transformed data (uniform marginals)
+  real<lower=1> alpha;      // Hyperparameter for sparsity
+}
+
+parameters {
+  matrix<lower=0, upper=1>[P, P] edge_probs_upper; // Upper triangular adjacency matrix
+  real<lower=1> theta;       // Gumbel copula parameter (>1 for positive dependence)
+}
+
+transformed parameters {
+  matrix<lower=0, upper=1>[P, P] edge_probs; // Symmetric adjacency matrix
+
+  for (i in 1:P) {
+    for (j in 1:P) {
+      if (i < j) {
+        edge_probs[i, j] = edge_probs_upper[i, j];
+        edge_probs[j, i] = edge_probs_upper[i, j];
+      } else if (i == j) {
+        edge_probs[i, j] = 0; // No self-loops
+      }
+    }
+  }
+}
+
+model {
+  // Prior: Sparsity constraint on edges
+  for (i in 1:(P - 1)) {
+    for (j in (i + 1):P) {
+      edge_probs_upper[i, j] ~ beta(alpha, 1); // Controls sparsity
+    }
+  }
+
+  // Likelihood using Gumbel copula
+  for (i in 1:P) {
+    for (j in (i + 1):P) {
+      if (edge_probs[i, j] > 0.5) { // Only consider strong edges
+        for (n in 1:N) {
+          real C_uv = exp(-((pow((-log(U[n, i])), theta) + pow((-log(U[n, j])), theta)) ^ (1 / theta)));
+          target += log(C_uv); // Log-likelihood of the copula
+        }
+      }
+    }
+  }
+}
+
+generated quantities {
+  matrix[P, P] sampled_graph; // Binary adjacency matrix
+  vector[P] tail_dependence;  // Tail dependence for each variable
+
+  for (i in 1:P) {
+    for (j in 1:P) {
+      if (i < j) {
+        sampled_graph[i, j] = bernoulli_rng(edge_probs[i, j]);
+        sampled_graph[j, i] = sampled_graph[i, j]; // Symmetry
+      } else {
+        sampled_graph[i, j] = 0; // No self-loops
+      }
+    }
+  }
+
+  // Compute tail dependence coefficient (lambda)
+  for (i in 1:P) {
+    real lambda_sum = 0;
+    int count_edges = 0;
+
+    for (j in 1:P) {
+      if (sampled_graph[i, j] == 1) { // Consider only selected edges
+        lambda_sum += 2 - 2^(1 / theta); // Gumbel tail dependence formula
+        count_edges += 1;
+      }
+    }
+    tail_dependence[i] = (count_edges > 0) ? lambda_sum / count_edges : 0; // Average lambda
+  }
+}

--- a/stan/Mixed_Data_Latent_Means_Model.stan
+++ b/stan/Mixed_Data_Latent_Means_Model.stan
@@ -8,8 +8,7 @@
 // The data are represented "properly", using appropriate parametric distributions
 // to evaluate the likelihoods (whose parameters are proportional to the latent means). 
 
-// TODO: negative binomial likelihood evaluation doesn't sample dispersion, which it should. 
-// TBD if an empirical bayes shrinkage should be used there (similar to Smyth's moderated statistics)
+// TODO: TBD if an empirical bayes shrinkage should be used on the NB dispersions (similar to Smyth's moderated statistics)
 
 data {
   int<lower=0> N;           // Number of samples

--- a/stan/Mixed_Data_Latent_Means_Model.stan
+++ b/stan/Mixed_Data_Latent_Means_Model.stan
@@ -1,0 +1,63 @@
+// Latent means model + adjacency probabilities
+
+
+// This structure model uses a non-copula ("spiritually copulic") matrix of latent means 
+// to store joint information (used colloquially) between variables and interpret those
+// latent means as edge probabilities. 
+
+// The data are represented "properly", using appropriate parametric distributions
+// to evaluate the likelihoods (whose parameters are proportional to the latent means). 
+
+// TODO: negative binomial likelihood evaluation doesn't sample dispersion, which it should. 
+// TBD if an empirical bayes shrinkage should be used there (similar to Smyth's moderated statistics)
+
+data {
+  int<lower=1> N;                  // Number of observations
+  int<lower=1> P;                  // Number of variables
+  int<lower=1> K;                  // Number of ordinal categories
+  matrix[N, P] continuous_data;    // Continuous data (Gaussian)
+  array[N, P] int<lower=0, upper=1> binary_data; // Binary data
+  array[N, P] int<lower=0, upper=K> ordinal_data; // Ordinal data
+  array[N, P] int<lower=0> count_data;   // Count data (geometric)
+}
+
+parameters {
+  matrix[P, P] Z;                  // Latent adjacency weights
+  matrix[N, P] mu;                 // Node-specific mean parameters
+  vector<lower=0>[P] sigma;        // Standard deviations for Gaussian
+  ordered[K - 1] cutpoints;        // Cutpoints for ordinal data
+}
+
+transformed parameters {
+  matrix[P, P] A;                  // Relaxed adjacency matrix
+  A = inv_logit(Z);                // Sigmoid transformation
+}
+
+model {
+  // Priors
+  to_vector(Z) ~ normal(0, 1);         // Sparsity-inducing prior
+  sigma ~ exponential(1);             // Half-Cauchy or Exponential prior
+  cutpoints ~ normal(0, 1);           // Prior for ordinal cutpoints
+  
+  // Likelihood
+  for (n in 1:N) {
+    for (i in 1:P) {
+      for (j in 1:P) {
+        if (i != j) {
+          // Continuous data likelihood
+          target += normal_lpdf(continuous_data[n, i] | A[i, j] * mu[n, j], sigma[j]);
+          
+          // Binary data likelihood (logistic regression)
+          target += bernoulli_logit_lpmf(binary_data[n, i] | A[i, j] * mu[n, j]);
+          
+          // Ordinal data likelihood
+          target += ordered_logistic_lpmf(ordinal_data[n, i] | A[i, j] * mu[n, j], cutpoints);
+          
+          // Count data likelihood (geometric with log-link)
+          target += neg_binomial_2_log_lpmf(count_data[n, i] | A[i, j] * mu[n, j], 1);  // 1 is dispersion parameter
+        }
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
I'm experimenting with structure modeling in response to Doug Lauffenburger's group's paper here: https://pmc.ncbi.nlm.nih.gov/articles/PMC11634979/

They propose Gaussian Graphical Models (GGMs) using partial correlation + gLASSO methods as a causal network, which generally makes sense. However, I frequently need to leverage non-gaussian data in such schemes. They also have non-gaussian data (e.g. vaccination status), but it seems to work for them. 

I think that a Bayesian extension (such that you can sample uncertainty in node connections explicitly) makes a lot of sense, and also extending variable types to non-gaussians is very likely a Good Idea. 

Reza Mohammedi also has some interesting papers on this: 

- https://arxiv.org/abs/2203.10118
- https://arxiv.org/abs/1904.09339

largely captured in their `bdgraphs` R package, focusing on birth-death modeling of the graph structure. These methods use MCMC, and I'm thinking that perhaps Stan's HMC could be a boon in running far fewer iterations (10k MCMC for large graphs -> 2k HMC).  

The models so far are: 

- a latent variable model seeking to capture joint structure via a matrix of means and infer a graphical structure based on the latent means. 
    - Currently, the model parameters are JUST the latent means, but they could/should probably be proportional to a second matrix of data-specific parameters. 
- a Gumble copula model that flips the previous model's information flow (from likelihoods -> structure to structure -> likelihood) but offers the ability to model tail dependence (which appears very attractive in data where only the extreme values "matter", like in flow cytometry lineage-marker distributions). 